### PR TITLE
fix: remove /tmp output in favor of streaming

### DIFF
--- a/app/convert/route.ts
+++ b/app/convert/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     // Define paths - assuming file is in public/videos/
     const inputPath = path.join(process.cwd(), "public", "videos", inputFile);
 
-    // Check if input file exists
+    // Check if input file exists.
     try {
       await fs.access(inputPath);
     } catch {


### PR DESCRIPTION
- switch to webm output to support streaming
- switch codes to support webm
- explicitly declare output format instead of relying on file extension
- switch from buffer to stream response
- remove content-length header since we are streaming